### PR TITLE
Fix issues with receiving keys in Doom 2

### DIFF
--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -185,7 +185,16 @@ boolean P_GiveWeapon(player_t* player, weapontype_t weapon, boolean dropped);
 boolean is_in_level(int ep, int map)
 {
     if (gamemode == commercial)
-        return map == gamemap;
+    {
+        // AP items have "episodes" but the actual game does not
+        switch (ep)
+        {
+            case 2: return (map + 11) == gamemap;
+            case 3: return (map + 20) == gamemap;
+            case 4: return (map + 30) == gamemap;
+            default: return map == gamemap;
+        }
+    }
     else
         return ep == gameepisode && map == gamemap;
 }
@@ -209,7 +218,7 @@ void on_ap_give_item(int doom_type, int ep, int map)
                 {
                     player->cards[it_bluecard] = !level_info->use_skull[0];
                     player->cards[it_blueskull] = level_info->use_skull[0];
-                    player->message = DEH_String(GOTBLUECARD);
+                    player->message = DEH_String((level_info->use_skull[0]) ? GOTBLUESKUL : GOTBLUECARD);
                     sound = sfx_keyup;
                 }
             }
@@ -222,7 +231,7 @@ void on_ap_give_item(int doom_type, int ep, int map)
                 {
                     player->cards[it_yellowcard] = !level_info->use_skull[1];
                     player->cards[it_yellowskull] = level_info->use_skull[1];
-	                player->message = DEH_String(GOTYELWCARD);
+	                player->message = DEH_String((level_info->use_skull[1]) ? GOTYELWSKUL : GOTYELWCARD);
                     sound = sfx_keyup;
                 }
             }
@@ -235,7 +244,7 @@ void on_ap_give_item(int doom_type, int ep, int map)
                 {
                     player->cards[it_redcard] = !level_info->use_skull[2];
                     player->cards[it_redskull] = level_info->use_skull[2];
-	                player->message = DEH_String(GOTREDCARD);
+	                player->message = DEH_String((level_info->use_skull[2]) ? GOTREDSKULL : GOTREDCARD);
                     sound = sfx_keyup;
                 }
             }

--- a/src/doom/d_main.c
+++ b/src/doom/d_main.c
@@ -184,19 +184,8 @@ boolean P_GiveWeapon(player_t* player, weapontype_t weapon, boolean dropped);
 
 boolean is_in_level(int ep, int map)
 {
-    if (gamemode == commercial)
-    {
-        // AP items have "episodes" but the actual game does not
-        switch (ep)
-        {
-            case 2: return (map + 11) == gamemap;
-            case 3: return (map + 20) == gamemap;
-            case 4: return (map + 30) == gamemap;
-            default: return map == gamemap;
-        }
-    }
-    else
-        return ep == gameepisode && map == gamemap;
+    ap_level_index_t idx = { ep - 1, map - 1 };
+    return gameepisode == ap_index_to_ep(idx) && gamemap == ap_index_to_map(idx);
 }
 
 


### PR DESCRIPTION
Previously, if you receive a key for a level in "episode" 2 or 3 in Doom 2, while you're currently in that level, you won't actually acquire it until you exit back to the hub and return. This fixes that, so it can be used immediately. Relatedly this also fixes acquiring keycards for the wrong level (being given MAP28's key while in MAP08, for instance).

The message that shows up in this case now also correctly distinguishes keycards and skull keys, as well.