### PR TITLE
Don't allow alive players to spawn or load in with 0 health (as zombies)

### DIFF
--- a/src/doom/g_game.c
+++ b/src/doom/g_game.c
@@ -1226,7 +1226,11 @@ void set_ap_player_states()
     p->cards[3] = level_state->keys[0] && level_info->use_skull[0];
     p->cards[4] = level_state->keys[1] && level_info->use_skull[1];
     p->cards[5] = level_state->keys[2] && level_info->use_skull[2];
-    
+
+    // respawn would-be zombies, if ap health somehow becomes zero
+    if (p->playerstate == PST_LIVE && p->health == 0)
+        p->health = 100;
+
     // mo
     if (p->mo)
     {


### PR DESCRIPTION
The zombie bug that people are experiencing is caused by `player->playerstate` being `PST_LIVE`, but `player->health` and `player->mo->health` both being zero.

If `ap_state.player_state.health` somehow gets set to zero, and a player tries to load a level under those conditions, the player will be stuck as a zombie (unless they're loading a save where they're already dead). There is at least one 100% reliable way to cause this: Die, quit the game while dead, and delete the save for the level you're on.

I'm certain that isn't the only possible case where people are getting stuck with zero health, because I can't imagine people are just going around deleting their save files on a whim. So, as a generalized fix that should stop it from _ever_ happening: if we notice us trying to spawn in a player as a zombie, ignore `ap_state.player_state.health` and instead spawn them with 100 health.