### PR TITLE
Text and number display fixes (crashes, widescreen issues, etc.)

### DIFF
--- a/src/doom/hu_stuff.c
+++ b/src/doom/hu_stuff.c
@@ -1070,18 +1070,31 @@ void HU_AddAPMessage(const char* message)
         if (message[j] != '\n')
         {
             int w = HULib_measureText(message + i, j - i);
-            if (w >= ORIGWIDTH + WIDESCREENDELTA - 8 && word_start == i)
+
+            if (w >= (ORIGWIDTH + WIDESCREENDELTA*2) - 8 || (j - i) + 2 >= HU_MAXLINELENGTH)
             {
-                if (j > i && word_start == i) --j;
-            }
-            else
-            {
-                if (w < ORIGWIDTH + WIDESCREENDELTA - 8 && (j - i) + 2 < HU_MAXLINELENGTH && j < len)
+                // out of space, but haven't advanced at all
+                if (j - 1 <= i)
                 {
-                    j++;
-                    continue;
+                    // just stop; we can't do anything further at this point
+                    printf("HU_AddAPMessage: cannot word wrap string (stopped at %i)\n", i);
+                    break;
                 }
-                if (j < len) j = word_start;
+                // out of space without finding another space to break at
+                else if (word_start == i)
+                {
+                    --j;
+                }
+                // if not at end of string, jump back to the last word
+                else if (j < len)
+                {
+                    j = word_start;
+                }
+            }
+            else if (j < len)
+            {
+                ++j;
+                continue;
             }
         }
         else
@@ -1133,6 +1146,7 @@ int HU_GetActiveAPMessageCount()
 
 void HU_UpdateAPMessagePosition(int i)
 {
+    w_ap_messages[i].l[0].x = HU_MSGX; // if window aspect ratio changed
     w_ap_messages[i].l[0].y = 3 * 8 - i * 8 - 4 * 8 + HU_GetActiveAPMessageCount() * 8 + ap_message_anim;
 }
 

--- a/src/doom/level_select.c
+++ b/src/doom/level_select.c
@@ -40,6 +40,10 @@ void WI_drawAnimatedBack(void);
 void WI_initVariables(wbstartstruct_t* wbstartstruct);
 void WI_loadData(void);
 
+// Functions in "st_stuff.c" needed for drawing things using status bar graphics
+void ST_DrawKey(int x, int y, int which, boolean is_skull);
+void ST_RightAlignedShortNum(int x, int y, int digit);
+void ST_LeftAlignedShortNum(int x, int y, int digit);
 
 typedef struct
 {
@@ -202,50 +206,6 @@ int selected_ep = 0;
 int prev_ep = 0;
 int ep_anim = 0;
 int urh_anim = 0;
-
-static const char* YELLOW_DIGIT_LUMP_NAMES[] = {
-    "STYSNUM0", "STYSNUM1", "STYSNUM2", "STYSNUM3", "STYSNUM4", 
-    "STYSNUM5", "STYSNUM6", "STYSNUM7", "STYSNUM8", "STYSNUM9"
-};
-
-
-void print_right_aligned_yellow_digit(int x, int y, int digit)
-{
-    x -= 4;
-
-    if (!digit)
-    {
-        V_DrawPatch(x, y, W_CacheLumpName(YELLOW_DIGIT_LUMP_NAMES[0], PU_CACHE));
-        return;
-    }
-
-    while (digit)
-    {
-        int i = digit % 10;
-        V_DrawPatch(x, y, W_CacheLumpName(YELLOW_DIGIT_LUMP_NAMES[i], PU_CACHE));
-        x -= 4;
-        digit /= 10;
-    }
-}
-
-
-void print_left_aligned_yellow_digit(int x, int y, int digit)
-{
-    if (!digit)
-    {
-        x += 4;
-    }
-
-    int len = 0;
-    int d = digit;
-    while (d)
-    {
-        len++;
-        d /= 10;
-    }
-    print_right_aligned_yellow_digit(x + len * 4, y, digit);
-}
-
 
 void restart_wi_anims()
 {
@@ -631,9 +591,6 @@ void DrawEpisodicLevelSelectStats()
             V_DrawPatch(x, y, W_CacheLumpName("WILOCK", PU_CACHE));
 
         // Keys
-        const char* key_lump_names[] = {"STKEYS0", "STKEYS1", "STKEYS2"};
-        const char* key_skull_lump_names[] = {"STKEYS3", "STKEYS4", "STKEYS5"};
-
         int key_x = 0;
         int key_y = 0;
 
@@ -645,12 +602,9 @@ void DrawEpisodicLevelSelectStats()
             {
                 if (ap_level_info->keys[k])
                 {
-                    const char* key_lump_name = key_lump_names[k];
-                    if (ap_level_info->use_skull[k])
-                        key_lump_name = key_skull_lump_names[k];
                     V_DrawPatch(key_x, key_y, W_CacheLumpName("KEYBG", PU_CACHE));
                     if (ap_level_state->keys[k])
-                        V_DrawPatch(key_x + 2, key_y + 1, W_CacheLumpName(key_lump_name, PU_CACHE));
+                        ST_DrawKey(key_x, key_y, k, ap_level_info->use_skull[k]);
                     key_x += key_h_spacing;
                 }
             }
@@ -663,11 +617,8 @@ void DrawEpisodicLevelSelectStats()
             {
                 if (ap_level_info->keys[k])
                 {
-                    const char* key_lump_name = key_lump_names[k];
-                    if (ap_level_info->use_skull[k])
-                        key_lump_name = key_skull_lump_names[k];
                     V_DrawPatch(key_x, key_y, W_CacheLumpName("KEYBG", PU_CACHE));
-                    V_DrawPatch(key_x + 2, key_y + 1, W_CacheLumpName(key_lump_name, PU_CACHE));
+                    ST_DrawKey(key_x, key_y, k, ap_level_info->use_skull[k]);
                     if (ap_level_state->keys[k])
                     {
                         if (level_pos->keys_offset < 0)
@@ -692,9 +643,9 @@ void DrawEpisodicLevelSelectStats()
             progress_x = key_x + 8;
             progress_y = key_y + 2;
         }
-        print_right_aligned_yellow_digit(progress_x, progress_y, ap_level_state->check_count);
+        ST_RightAlignedShortNum(progress_x, progress_y, ap_level_state->check_count);
         V_DrawPatch(progress_x + 1, progress_y, W_CacheLumpName("STYSLASH", PU_CACHE));
-        print_left_aligned_yellow_digit(progress_x + 8, progress_y, ap_level_info->check_count - ap_level_info->sanity_check_count);
+        ST_LeftAlignedShortNum(progress_x + 8, progress_y, ap_level_info->check_count - ap_level_info->sanity_check_count);
 
         // "You are here"
         if (i == selected_level[selected_ep] && urh_anim < 25)

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -1288,21 +1288,23 @@ void M_MusicVol(int choice)
 
 void draw_apdoom_version(void)
 {
-    const char* version_text = APDOOM_VERSION_FULL_TEXT;
-    auto len = strlen(APDOOM_VERSION_FULL_TEXT);
-    int x = 0;
-    for (int i = 0; i < len; ++i)
+    patch_t *patch;
+    int x = HU_MSGX;
+
+    for (const char *p = APDOOM_VERSION_FULL_TEXT; *p; ++p)
     {
-        if (version_text[i] == ' ')
-        {
+        if (*p == ' ' || *p < HU_FONTSTART || *p > HU_FONTEND)
+            patch = NULL;
+        else
+            patch = hu_font[(unsigned)*p - HU_FONTSTART];
+
+        if (!patch)
             x += 8;
-            continue;
+        else
+        {
+            V_DrawPatchDirect(x, ORIGHEIGHT - hu_font[0]->height, patch);
+            x += patch->width;
         }
-        const char* char_name[9];
-        sprintf(char_name, "STCFN0%i", (int)version_text[i]);
-        patch_t* patch = W_CacheLumpName(char_name, PU_CACHE);
-        V_DrawPatchDirect(x, 200 - 8, patch);
-        x += patch->width;
     }
 }
 

--- a/src/doom/m_menu.c
+++ b/src/doom/m_menu.c
@@ -3277,7 +3277,7 @@ void M_Drawer (void)
 
     
     if (gamemode == commercial)
-        V_DrawPatch(0, 0, W_CacheLumpName("INTERPIC", PU_CACHE));
+        V_DrawPatchFullScreen(W_CacheLumpName("INTERPIC", PU_CACHE), false);
     if (currentMenu->routine)
 	currentMenu->routine();         // call Draw routine
     

--- a/src/doom/st_stuff.c
+++ b/src/doom/st_stuff.c
@@ -2515,3 +2515,42 @@ void ST_DrawDemoTimer (const int time)
 	dp_translucent = false;
 }
 
+//--------------------------------------------------------------------------
+// [AP] used for level select, to avoid re-tagging static graphics (causing later memory issues)
+
+void ST_DrawKey(int x, int y, int which, boolean is_skull)
+{
+	if (is_skull)
+		which += 3;
+
+    V_DrawPatch(x + 2, y + 1, keys[which]);
+}
+
+void ST_RightAlignedShortNum(int x, int y, int digit)
+{
+    x -= 4;
+
+    do
+    {
+        int i = digit % 10;
+        V_DrawPatch(x, y, shortnum[i]);
+        x -= 4;
+        digit /= 10;
+    }
+    while (digit);
+}
+
+void ST_LeftAlignedShortNum(int x, int y, int digit)
+{
+    int len = 0;
+    int i = digit;
+
+    do
+    {
+        len += 4;
+        i /= 10;
+    }
+    while (i);
+
+    ST_RightAlignedShortNum(x + len, y, digit);
+}

--- a/src/heretic/ap_msg.c
+++ b/src/heretic/ap_msg.c
@@ -59,18 +59,31 @@ void HU_AddAPMessage(const char* message)
         if (message[j] != '\n')
         {
             int w = MN_TextAWidth_len(message + i, j - i);
-            if (w >= ORIGWIDTH + WIDESCREENDELTA - 8 && word_start == i)
+
+            if (w >= (ORIGWIDTH + WIDESCREENDELTA*2) - 8 || (j - i) + 2 >= HU_MAXLINELENGTH)
             {
-                if (j > i && word_start == i) --j;
-            }
-            else
-            {
-                if (w < ORIGWIDTH + WIDESCREENDELTA - 8 && (j - i) + 2 < HU_MAXLINELENGTH && j < len)
+                // out of space, but haven't advanced at all
+                if (j - 1 <= i)
                 {
-                    j++;
-                    continue;
+                    // just stop; we can't do anything further at this point
+                    printf("HU_AddAPMessage: cannot word wrap string (stopped at %i)\n", i);
+                    break;
                 }
-                if (j < len) j = word_start;
+                // out of space without finding another space to break at
+                else if (word_start == i)
+                {
+                    --j;
+                }
+                // if not at end of string, jump back to the last word
+                else if (j < len)
+                {
+                    j = word_start;
+                }
+            }
+            else if (j < len)
+            {
+                ++j;
+                continue;
             }
         }
         else
@@ -99,7 +112,7 @@ void HU_DrawAPMessages()
     {
         if (i == 0 && ap_message_anim > 0 && HU_GetActiveAPMessageCount() == 4) continue;
         if (ap_messages[i].on)
-            MN_DrTextA(ap_messages[i].message, 0, ap_messages[i].y);
+            MN_DrTextA(ap_messages[i].message, (0 - WIDESCREENDELTA), ap_messages[i].y);
     }
 }
 

--- a/src/heretic/level_select.c
+++ b/src/heretic/level_select.c
@@ -30,6 +30,9 @@
 
 extern boolean automapactive;
 
+// Functions in "sb_bar.c" needed for drawing things using status bar graphics
+void SB_RightAlignedSmallNum(int x, int y, int digit);
+void SB_LeftAlignedSmallNum(int x, int y, int digit);
 
 typedef struct
 {
@@ -196,51 +199,6 @@ int prev_ep = 0;
 int ep_anim = 0;
 int urh_anim = 0;
 int activating_level_select_anim = 200;
-
-
-
-static const char* YELLOW_DIGIT_LUMP_NAMES[] = {
-    "SMALLIN0", "SMALLIN1", "SMALLIN2", "SMALLIN3", "SMALLIN4", 
-    "SMALLIN5", "SMALLIN6", "SMALLIN7", "SMALLIN8", "SMALLIN9"
-};
-
-
-void print_right_aligned_yellow_digit(int x, int y, int digit)
-{
-    x -= 4;
-
-    if (!digit)
-    {
-        V_DrawPatch(x, y, W_CacheLumpName(YELLOW_DIGIT_LUMP_NAMES[0], PU_CACHE));
-        return;
-    }
-
-    while (digit)
-    {
-        int i = digit % 10;
-        V_DrawPatch(x, y, W_CacheLumpName(YELLOW_DIGIT_LUMP_NAMES[i], PU_CACHE));
-        x -= 4;
-        digit /= 10;
-    }
-}
-
-
-void print_left_aligned_yellow_digit(int x, int y, int digit)
-{
-    if (!digit)
-    {
-        x += 4;
-    }
-
-    int len = 0;
-    int d = digit;
-    while (d)
-    {
-        len++;
-        d /= 10;
-    }
-    print_right_aligned_yellow_digit(x + len * 4, y, digit);
-}
 
 
 void play_level(int ep, int lvl)
@@ -613,9 +571,9 @@ void DrawEpisodicLevelSelectStats()
             }
 
             // Progress
-            print_right_aligned_yellow_digit(x + 30 + text_w - 4, y - 1, ap_level_state->check_count);
+            SB_RightAlignedSmallNum(x + 30 + text_w - 4, y - 1, ap_level_state->check_count);
             V_DrawPatch(x + 30 + text_w - 3, y - 1, W_CacheLumpName("STYSLASH", PU_CACHE));
-            print_left_aligned_yellow_digit(x + 30 + text_w + 3, y - 1, ap_state.check_sanity ? ap_level_info->check_count : ap_level_info->check_count - ap_level_info->sanity_check_count);
+            SB_LeftAlignedSmallNum(x + 30 + text_w + 3, y - 1, ap_state.check_sanity ? ap_level_info->check_count : ap_level_info->check_count - ap_level_info->sanity_check_count);
         }
         else
         {
@@ -644,9 +602,9 @@ void DrawEpisodicLevelSelectStats()
             }
 
             // Progress
-            print_right_aligned_yellow_digit(x - 4, y + stat_y_offset, ap_level_state->check_count);
+            SB_RightAlignedSmallNum(x - 4, y + stat_y_offset, ap_level_state->check_count);
             V_DrawPatch(x - 3, y + stat_y_offset, W_CacheLumpName("STYSLASH", PU_CACHE));
-            print_left_aligned_yellow_digit(x + 3, y + stat_y_offset, ap_state.check_sanity ? ap_level_info->check_count : ap_level_info->check_count - ap_level_info->sanity_check_count);
+            SB_LeftAlignedSmallNum(x + 3, y + stat_y_offset, ap_state.check_sanity ? ap_level_info->check_count : ap_level_info->check_count - ap_level_info->sanity_check_count);
         }
     }
 

--- a/src/heretic/sb_bar.c
+++ b/src/heretic/sb_bar.c
@@ -1758,3 +1758,35 @@ static void CheatNoTargetFunc(player_t *player, Cheat_t *cheat)
         P_SetMessage(player, DEH_String(TXT_CHEATNOTARGETOFF), false);
     }
 }
+
+//--------------------------------------------------------------------------
+// [AP] used for level select, to avoid re-tagging static graphics (causing later memory issues)
+
+void SB_RightAlignedSmallNum(int x, int y, int digit)
+{
+    x -= 4;
+
+    do
+    {
+        int i = digit % 10;
+        V_DrawPatch(x, y, PatchSmNumbers[i]);
+        x -= 4;
+        digit /= 10;
+    }
+    while (digit);
+}
+
+void SB_LeftAlignedSmallNum(int x, int y, int digit)
+{
+    int len = 0;
+    int i = digit;
+
+    do
+    {
+        len += 4;
+        i /= 10;
+    }
+    while (i);
+
+    SB_RightAlignedSmallNum(x + len, y, digit);
+}


### PR DESCRIPTION
This is a bunch of fixes, all revolving around the heads-up display and text elements that APDoom has added. The first two of them fix game crashes and/or hangs, the others are just to make the visuals a bit prettier and more consistent.

- For Doom and Doom II: in `draw_apdoom_version`, the `STCFNnnn` lumps were being fetched directly by W_CacheLumpName. This was changed to use `hu_font` instead.
  - While at surface level the original method works fine, it had the side effect of setting the tags of any HU font characters used in the version display to `PU_CACHE` -- it can be freed at any later time if the memory manager wants it back.
  - Doom already handles the HU font itself, in `hu_font`, tagged as `PU_STATIC` -- it expects them to never be freed unless explicitly done.
  - Because of the above tag change, those patches could be freed out from under the rest of the program. This caused completely random and unpredictable behavior; sometimes manifesting as infinite loops, sometimes as segfaults, sometimes just as random characters disappearing from heads-up displays.
  - This doesn't apply to Heretic; it handles FontA entirely differently, so the relevant function in that game was not changed.
- For all games: Like the above change, the level select screens of both Doom and Heretic previously used the small numbers and key graphics directly. The relevant functions have been changed and moved, so that they can access the statically-allocated versions of those patches instead.
  - The old behavior usually manifested as numbers disappearing from the HUD (for example, the count of an inventory item in Heretic), followed by a crash shortly after from trying to draw garbage to the screen.
- For all games: The word wrapping function for AP messages was rewritten, because it could cause the game to hang.
  - Previously, if the maximum string length was reached without reaching the edge of the screen, and there were no spaces to separate at, the game would hang in an infinite loop. This is not normally possible in 4:3 aspect ratio, but in widescreen aspect ratios it is possible for someone to send a string of 80 or more 'I's to cause this to happen.
  - If the string _legitimately_ cannot be word wrapped (because, for example, someone has loaded a PWAD with an excessively large font, where one character exceeds the bounds of the screen), it now bails out entirely, matching the behavior of the rest of the game.
- For all games: AP Messages are now always aligned to the left of the screen, regardless of aspect ratio, and even if the aspect ratio is adjusted in the middle of the game.
- For Doom II specifically: The menu background that APDoom added now also blacks out the rest of the screen, instead of showing gameplay through it in widescreen aspect ratios.