### PR TITLE
Fix off-by-one errors causing Heretic to never spawn ethereal arrows …

### DIFF
--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -930,7 +930,7 @@ void P_LoadThings(int lump)
                         int rnd = rand() % total;
                         if (rnd < ratios[0])
                         {
-                            switch (rand()%2)
+                            switch (rand()%3)
                             {
                                 case 0: things_type_remap[i] = 81; break; // Crystal Vial
                                 case 1: things_type_remap[i] = 10; break; // Wand Crystal
@@ -949,7 +949,7 @@ void P_LoadThings(int lump)
                         }
                         else
                         {
-                            switch (rand()%6)
+                            switch (rand()%7)
                             {
                                 case 0: things_type_remap[i] = 12; break; // Crystal Geode
                                 case 1: things_type_remap[i] = 55; break; // Energy Orb

--- a/src/heretic/p_setup.c
+++ b/src/heretic/p_setup.c
@@ -926,6 +926,7 @@ void P_LoadThings(int lump)
                     case 19: // Quiver of Ethereal Arrows
                     case 10: // Wand Crystal
                     case 81: // Crystal Vial
+                    case 82: // Quartz Flask
                     {
                         int rnd = rand() % total;
                         if (rnd < ratios[0])


### PR DESCRIPTION
…or quartz flasks in item shuffling

`rand()%N` returns a random number from 0 to N-1. In this block in Heretic's p_setup.c, there are two blocks with `rand()%2` and `case 0: [...] case 1: [...] case 2: [...]` and `rand()%6` with cases going up to 6, causing both of the last cases (Ethereal Arrows and Quartz Flasks) to never be rolled for item shuffle replacement. This change fixes both of these off-by-one errors to ensure both of those items can spawn.